### PR TITLE
Fix typename tokenization bug

### DIFF
--- a/ctypesgencore/parser/cparser.py
+++ b/ctypesgencore/parser/cparser.py
@@ -58,7 +58,9 @@ class CLexer(object):
                 t.type = t.value.upper()
             elif t.type == 'IDENTIFIER' and t.value in self.type_names:
                 if (self.pos < 2 or self.tokens[self.pos-2].type not in
-                    ('ENUM', 'STRUCT', 'UNION')):
+                    ('VOID', '_BOOL', 'CHAR', 'SHORT', 'INT', 'LONG',
+                        'FLOAT', 'DOUBLE', 'SIGNED', 'UNSIGNED', 'ENUM',
+                        'STRUCT', 'UNION', 'TYPE_NAME')):
                     t.type = 'TYPE_NAME'
 
             t.lexer = self


### PR DESCRIPTION
This fixes the incorrect lexing of the following code:

    typedef int Int;
    struct Struct { int Int; };

Before this patch Struct.Int would incorrectly be tokenized as a
TYPE_NAME and not an IDENTIFIER.