### PR TITLE
Fixed unittests on Windows with python prior to 3.7

### DIFF
--- a/ctypesgen/test/testsuite.py
+++ b/ctypesgen/test/testsuite.py
@@ -2164,7 +2164,10 @@ class MainTest(unittest.TestCase):
 
     @staticmethod
     def _exec(args):
-        pyexec = "python{}".format(sys.version_info.major)
+        if sys.platform == "win32":
+            pyexec = "python"
+        else:
+            pyexec = "python{}".format(sys.version_info.major)
         p = Popen([pyexec, MainTest.script] + args, stdout=PIPE, stderr=PIPE)
         o, e = p.communicate()
         return o, e, p.returncode


### PR DESCRIPTION
Regarding issue #79: unittests fail on Win7
This fixes python3.6 on Win7 last issues.