### PR TITLE
Add relevant name formats to posix library loader

### DIFF
--- a/ctypesgen/libraryloader.py
+++ b/ctypesgen/libraryloader.py
@@ -193,6 +193,12 @@ class PosixLibraryLoader(LibraryLoader):
 
     _include = re.compile(r"^\s*include\s+(?P<pattern>.*)")
 
+    name_formats = [
+        "lib%s.so",
+        "%s.so",
+        "%s"
+    ]
+
     class _Directories(dict):
         def __init__(self):
             self.order = 0


### PR DESCRIPTION
Added name formats so the library filename does not have to be specified directly. Useful for cross-platform wrappers